### PR TITLE
Adds Woodpecker build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [Computed Interface](https://github.com/rezo-labs/directus-extension-computed-interface) - Perform computed value based on other fields.
 - [Inline Form Interface](https://github.com/hanneskuettner/directus-extension-inline-form-interface) - Edit M2O relations in an inline form contained in the parent record.
 - [Tab Group Interface](https://github.com/hanneskuettner/directus-extension-group-tabs-interface) - Display groups as tab panels, as a pretty, space saving alternative to the accordion group.
+- [Woodpecker Build Status](https://github.com/sguter90/directus-extension-woodpecker-build-status) - Adds status bar for [Woodpecker](https://woodpecker-ci.org/) pipeline build status to Directus UI.
 
 ## Articles
 


### PR DESCRIPTION
I wrote an direcuts extension for showing the current woodpecker build status.

e.g. Changes in a directus collection trigger pipeline in woodpecker. 
So the user gets a visual feedbeck if the pipeline is still running or failed.